### PR TITLE
Add alt attribute to cover, include it in TOC

### DIFF
--- a/get_unsong.py
+++ b/get_unsong.py
@@ -79,7 +79,8 @@ def create_book():
     fp.write(header)
     fp.write("<header>")
     if INCLUDE_AUTOGEN_COVER:
-        fp.write("<img src='%s' alt=''>" % make_cover())
+        fp.write("<h1>Cover</h1>")
+        fp.write("<img src='%s' alt='Unsong by Scott Alexander'>" % make_cover())
         
     fp.write("<main>")
     fp.write("\n\n\n".join(nchapters))


### PR DESCRIPTION
Just realiced this creates a conflict (sorry), but I don't know how to fix it without making a pull request really dependent on another.

This adds an alt attribute to the cover image, and makes an h1 for it to appear in contents (feel free to remove the heading, I am used to that but I understand it won't add anything).