### PR TITLE
Make `create_unsong_book.bat` a truly polyglot bash/batch script

### DIFF
--- a/create_unsong_book.bat
+++ b/create_unsong_book.bat
@@ -1,3 +1,33 @@
-pip3 install -r requirements.txt -qq
-python3 get_unsong.py || python get_unsong.py
-ebook-convert ebooks/Unsong.html ebooks/Unsong.epub --level1-toc="//h:h1" --level2-toc="//h:h2" --no-default-epub-cover --authors "Scott Alexander" --language en
+: << '____CMD____'
+
+
+@echo off
+
+call pip3 install -r ".\requirements.txt" -qq
+call python3 ".\get_unsong.py" || call python ".\get_unsong.py"
+
+call ebook-convert ".\ebooks\Unsong.html" ".\ebooks\Unsong.epub" ^
+ --level1-toc="//h:h1" ^
+ --level2-toc="//h:h2" ^
+ --no-default-epub-cover ^
+ --authors "Scott Alexander" ^
+ --language en
+
+goto :EOF
+
+
+____CMD____
+
+
+
+pip3 install -r "./requirements.txt" -qq
+python3 "./get_unsong.py" || python "./get_unsong.py"
+
+ebook-convert "./ebooks/Unsong.html" "./ebooks/Unsong.epub" \
+  --level1-toc="//h:h1" \
+  --level2-toc="//h:h2" \
+  --no-default-epub-cover \
+  --authors "Scott Alexander" \
+  --language en
+
+exit 0


### PR DESCRIPTION
This should prevent execution errors due to quirky Windows batch file handling, e.g. issue #20.

The source for this kind of polyglot script comes from `cmdize` by @ildar-shaimordanov, see here:
https://github.com/ildar-shaimordanov/my-scripts/tree/master/cmd/cmdize#sh